### PR TITLE
chore: update npm dependencies to current versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,7 +317,7 @@ module.exports = {
 			return getPartialDependencies(template, config)
 				.then(function (dependencies) {
 					// filter any dependencies from config.partials and return the result
-					return _.pick(dependencies, function (partialPath) {
+					return _.pickBy(dependencies, function (partialPath) {
 						return partialPath !== null;
 					});
 				});

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "resolved": "https://registry.npmjs.org/@retailmenot/roux/-/roux-1.0.4.tgz",
       "integrity": "sha1-Kk7+3Rhg3p3JiL+pm2Ap1RyAIBQ=",
       "requires": {
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "core-error-predicates": "1.1.0",
         "debug": "2.6.9",
         "glob": "6.0.4",
@@ -43,6 +43,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
@@ -218,9 +223,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "boom": {
       "version": "2.10.1",
@@ -484,9 +489,9 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1337,9 +1342,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "log-driver": {
       "version": "1.2.5",
@@ -3824,7 +3829,7 @@
       "dev": true,
       "requires": {
         "bind-obj-methods": "1.0.0",
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "clean-yaml-object": "0.1.0",
         "color-support": "1.1.3",
         "coveralls": "2.13.3",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   },
   "dependencies": {
     "@retailmenot/roux": "^1.0.1",
-    "bluebird": "^3.1.1",
-    "debug": "^2.2.0",
+    "bluebird": "^3.5.1",
+    "debug": "^3.1.0",
     "handlebars": "^4.0.5",
-    "lodash": "^3.10.1"
+    "lodash": "^4.17.4"
   }
 }


### PR DESCRIPTION
- update to bluebird@3.5.1
- update to debug@3.1.0
- update to lodash@4.17.4
- change _.pick() to _.pickBy that was introduced in lodash@4.0.0