### PR TITLE
chore: remove node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "10"
   - "8"
-  - "6"
 script:
   - npm run lint
   - npm test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/RetailMeNotSandbox/roux-handlebars-tools.git"
   },
   "engines": {
-    "node": ">= 4"
+    "node": ">=8"
   },
   "keywords": [
     "roux",
@@ -24,7 +24,8 @@
     "Eric Capps <ecapps@rmn.com>",
     "Lon Ingram <lingram@rmn.com>",
     "Kyle Smith <kbsmith@rmn.com>",
-    "Luke Zilioli <lzilioli@rmn.com>"
+    "Luke Zilioli <lzilioli@rmn.com>",
+    "Ray Pierce <ray@digitalpierce.com>"
   ],
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
* Remove node 6 from the travis.yml
* Bump the node engine versions to >=8